### PR TITLE
Bug fix where nth function didnt iterate

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,6 +102,7 @@ assert.nth = function (n, assertion) {
 				this.assertion(n + ' position is not passing assertion: ' + err.message);
 			}
 		} else {
+			i++;
 			cb(null, obj);
 		}
 	});


### PR DESCRIPTION
This patch fixes a bug where the nth function wasn't iterating properly. The assert.second test was passing because the function passed to do the assertion was never called.
